### PR TITLE
chore: replace groupId with com.example

### DIFF
--- a/boot-receive/pom.xml
+++ b/boot-receive/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>cn.wolfcode.wolf2w</groupId>
+    <groupId>com.example</groupId>
     <artifactId>boot-send</artifactId>
     <version>1.0-SNAPSHOT</version>
 

--- a/boot-send/pom.xml
+++ b/boot-send/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>cn.wolfcode.wolf2w</groupId>
+    <groupId>com.example</groupId>
     <artifactId>boot-send</artifactId>
     <version>1.0-SNAPSHOT</version>
 

--- a/java-receive/pom.xml
+++ b/java-receive/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>cn.wolfcode.wolf2w</groupId>
+    <groupId>com.example</groupId>
     <artifactId>java-send</artifactId>
     <version>1.0-SNAPSHOT</version>
 

--- a/java-send/pom.xml
+++ b/java-send/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>cn.wolfcode.wolf2w</groupId>
+    <groupId>com.example</groupId>
     <artifactId>java-send</artifactId>
     <version>1.0-SNAPSHOT</version>
 


### PR DESCRIPTION
## Summary
- replace Maven groupId `cn.wolfcode.wolf2w` with `com.example`

## Testing
- `mvn -q -f boot-send/pom.xml test` *(fails: Non-resolvable parent POM due to Network is unreachable)*
- `mvn -q -f java-send/pom.xml test` *(fails: Could not transfer plugin due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4f5aca3c833084603a77e3d9bb26